### PR TITLE
add send-recv  tutorial adapted from mpitutorial.com and ipython-parallel intro

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -4,3 +4,6 @@ parts:
   - caption: Introduction
     chapters:
       - file: notebooks/introduction
+      - file: notebooks/intro-mpi/intro-mpi
+        sections:
+          - file: notebooks/intro-mpi/send-recv

--- a/notebooks/intro-mpi/intro-mpi.ipynb
+++ b/notebooks/intro-mpi/intro-mpi.ipynb
@@ -1,0 +1,573 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "04225a2b-4505-4ace-9ae9-fc370e31b105",
+   "metadata": {},
+   "source": [
+    "# Introduction to MPI\n",
+    "\n",
+    "This section adapts [mpitutorial.com] materials using IPython Parallel and mpi4py to run MPI code in Jupyter notebooks.\n",
+    "We won't go into detail in using IPython Parallel, but cover the key bits for getting started.\n",
+    "\n",
+    "[mpitutorial.com] materials are used under the MIT License.\n",
+    "\n",
+    "[IPython Parallel]: https://ipyparallel.readthedocs.io\n",
+    "\n",
+    "[mpitutorial.com]: https://mpitutorial.com"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "39a1c079-9f64-46cd-b4cc-148bc5bc4f9a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting 2 engines with <class 'ipyparallel.cluster.launcher.MPIEngineSetLauncher'>\n",
+      "100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:01<00:00,  1.51engine/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import ipyparallel as ipp\n",
+    "\n",
+    "# create a cluster\n",
+    "cluster = ipp.Cluster(engines=\"mpi\", n=2)\n",
+    "# start that cluster and connect to it\n",
+    "rc = cluster.start_and_connect_sync()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70b316ca-38da-47a0-b011-8e59f5630915",
+   "metadata": {},
+   "source": [
+    "What did that do?\n",
+    "\n",
+    "```\n",
+    "mpiexec -n 2 python -m ipyparallel.engine --mpi\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "acf0a84c-1154-47a6-a250-29cdcd38e8a8",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['mpiexec',\n",
+       " '-n',\n",
+       " '2',\n",
+       " '/Users/minrk/conda/envs/scan/bin/python',\n",
+       " '-m',\n",
+       " 'ipyparallel.engine',\n",
+       " '--mpi']"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cluster.engine_set.args"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e1c9bc6-5818-429c-b184-c0d2cbcde469",
+   "metadata": {},
+   "source": [
+    "If we 'activate' the client,\n",
+    "it registers magics with IPython, so we can use `%%px` to run cells on the _engines_\n",
+    "instead of in the local notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "01ad3592-ae8c-4335-a8fc-d146a9af6e72",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<DirectView all>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rc.activate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "486f9893-2677-45a8-b845-c8cba9fa03e8",
+   "metadata": {},
+   "source": [
+    "Now we have `%%px` available:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "9d606eeb-b45c-4611-9490-80cc182c081d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;31mOut[0:5]: \u001b[0m37246"
+      ]
+     },
+     "metadata": {
+      "after": null,
+      "completed": null,
+      "data": {},
+      "engine_id": 0,
+      "engine_uuid": "59435fd5-fa5a7daceae7d4f7308a42e0",
+      "error": null,
+      "execute_input": "import os\npid = os.getpid()\npid\n",
+      "execute_result": {
+       "data": {
+        "text/plain": "37246"
+       },
+       "execution_count": 5,
+       "metadata": {}
+      },
+      "follow": null,
+      "msg_id": null,
+      "outputs": [],
+      "received": null,
+      "started": null,
+      "status": null,
+      "stderr": "",
+      "stdout": "",
+      "submitted": "2023-04-12T07:36:50.848128Z"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;31mOut[1:5]: \u001b[0m37247"
+      ]
+     },
+     "metadata": {
+      "after": null,
+      "completed": null,
+      "data": {},
+      "engine_id": 1,
+      "engine_uuid": "35610757-3e903e1a636a9a24d1811bee",
+      "error": null,
+      "execute_input": "import os\npid = os.getpid()\npid\n",
+      "execute_result": {
+       "data": {
+        "text/plain": "37247"
+       },
+       "execution_count": 5,
+       "metadata": {}
+      },
+      "follow": null,
+      "msg_id": null,
+      "outputs": [],
+      "received": null,
+      "started": null,
+      "status": null,
+      "stderr": "",
+      "stdout": "",
+      "submitted": "2023-04-12T07:36:50.848409Z"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%px\n",
+    "import os\n",
+    "pid = os.getpid()\n",
+    "pid"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4d42e05e-02f2-4943-84f6-97865c7f902c",
+   "metadata": {},
+   "source": [
+    "A cell passed to `%%px` is run on _all engines at once_.\n",
+    "This is the equivalent of `mpiexec myscript.py`, when running noninteractive MPI.\n",
+    "\n",
+    "From now on, notebooks will start with a brief boilerplate to start and register the cluster,\n",
+    "so we can use `%%px`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01e614d2-77a2-4892-9e18-2cca29410ee0",
+   "metadata": {},
+   "source": [
+    "## Rank and size\n",
+    "\n",
+    "Our very first MPI code, to test `%%px`.\n",
+    "We are going to get the \"MPI World communicator\".\n",
+    "\n",
+    "The **rank** is the integer id of the current process,\n",
+    "while the **size** is the number of processes in the communicator."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "1184e9f8-27aa-43b8-b758-28a4bd3ae1c0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[stdout:0] I am rank 0 / 2\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[stdout:1] I am rank 1 / 2\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%px\n",
+    "# Find out rank, size\n",
+    "from mpi4py import MPI\n",
+    "\n",
+    "comm = MPI.COMM_WORLD\n",
+    "rank = comm.rank\n",
+    "size = comm.size\n",
+    "\n",
+    "print(f\"I am rank {rank} / {size}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e56e64a8-6e5b-4f17-ad18-a3da42788aea",
+   "metadata": {},
+   "source": [
+    "In IPython Parallel, the state is _persistent_.\n",
+    "This means the `rank` and `size` variables can be used in subsequent cells:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ab69bedd-4c50-4138-9f02-1988190d9956",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[stdout:0] Rank 0 has PID 37246\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[stdout:1] Rank 1 has PID 37247\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%px\n",
+    "print(f\"Rank {rank} has PID {pid}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34033b7a-c4bd-4992-b97e-805c61ce1729",
+   "metadata": {},
+   "source": [
+    "To translate a notebook written with `%%px` to a script for `mpiexec`, you would concatenate all the `%%px` cells into a single `.py` file.\n",
+    "\n",
+    "\n",
+    "Now we can stop the cluster if we want.\n",
+    "It should get cleaned up automatically when the notebook exits, but it's good to be explicit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "6a387fa4-5f74-41b4-8018-6af8ebd9c4a3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Stopping controller\n",
+      "Controller stopped: {'exit_code': 0, 'pid': 37230, 'identifier': 'ipcontroller-1681284456-mwao-37042'}\n",
+      "Stopping engine(s): 1681284457\n",
+      "engine set stopped 1681284457: {'exit_code': 0, 'pid': 37244, 'identifier': 'ipengine-1681284456-mwao-1681284457-37042'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "cluster.stop_cluster_sync()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "00075b7ed8c444eb97071a3707e50303": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0c3ca24d35fc4dc88c1fa23905ccfdc1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "16056c4de69e4209ace26e5b72f73cc8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "42dad6562c97491691e977d9b45d1ca2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "442f4995d9494629ac34b663e1a313bc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_77832571dc9945699fa431aaf60f24a9",
+       "style": "IPY_MODEL_9fd188b48db842dfa8e2c7a7cd1b23cc",
+       "value": " 4/4 [00:02&lt;00:00,  1.96engine/s]"
+      }
+     },
+     "4b512d642a6840d9939b743196564cf2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "572b4a346aec4d81be009a3ac2da2612": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_00075b7ed8c444eb97071a3707e50303",
+       "max": 4,
+       "style": "IPY_MODEL_42dad6562c97491691e977d9b45d1ca2",
+       "value": 4
+      }
+     },
+     "662312ef5f274591b84e3d644ac3e0d1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "6624a6cb4c28493d9c4aa1576d226946": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "68e50b829ba94a9aa73b29533cc7bef1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_9ded3a6800244a2c80d9a1bcaa9a4a5b",
+       "style": "IPY_MODEL_8de4c73f29c441ba91a4aed26f9b06bb",
+       "value": "100%"
+      }
+     },
+     "77832571dc9945699fa431aaf60f24a9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7d56b4fa55be4efb96f8d47a4fcff66e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_7e774ce0eb6c4b008764245c5f9db291",
+        "IPY_MODEL_b2997f4ca3224e28a6238c0ed1e67def",
+        "IPY_MODEL_c161a918e88e4d8b82f777a85b40278d"
+       ],
+       "layout": "IPY_MODEL_c88715f7a1b8410e9d72b28e19703194"
+      }
+     },
+     "7e774ce0eb6c4b008764245c5f9db291": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_9bddffbc41eb44a99ec28c7e2af77ffb",
+       "style": "IPY_MODEL_662312ef5f274591b84e3d644ac3e0d1",
+       "value": "100%"
+      }
+     },
+     "8de4c73f29c441ba91a4aed26f9b06bb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "9bddffbc41eb44a99ec28c7e2af77ffb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9ded3a6800244a2c80d9a1bcaa9a4a5b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9fd188b48db842dfa8e2c7a7cd1b23cc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "b2997f4ca3224e28a6238c0ed1e67def": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_4b512d642a6840d9939b743196564cf2",
+       "max": 2,
+       "style": "IPY_MODEL_0c3ca24d35fc4dc88c1fa23905ccfdc1",
+       "value": 2
+      }
+     },
+     "c161a918e88e4d8b82f777a85b40278d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6624a6cb4c28493d9c4aa1576d226946",
+       "style": "IPY_MODEL_ce92ee5594924e63af2e9e3ce8ae9154",
+       "value": " 2/2 [00:01&lt;00:00,  1.56s/engine]"
+      }
+     },
+     "c88715f7a1b8410e9d72b28e19703194": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ce92ee5594924e63af2e9e3ce8ae9154": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "d6f225fcfd5943cbabb0b0c6cd356ca6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_68e50b829ba94a9aa73b29533cc7bef1",
+        "IPY_MODEL_572b4a346aec4d81be009a3ac2da2612",
+        "IPY_MODEL_442f4995d9494629ac34b663e1a313bc"
+       ],
+       "layout": "IPY_MODEL_16056c4de69e4209ace26e5b72f73cc8"
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/intro-mpi/send-recv.ipynb
+++ b/notebooks/intro-mpi/send-recv.ipynb
@@ -1,0 +1,616 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "04225a2b-4505-4ace-9ae9-fc370e31b105",
+   "metadata": {},
+   "source": [
+    "# MPI Send and Receive\n",
+    "\n",
+    "Sending and receiving data with MPI.\n",
+    "\n",
+    "See [the original tutorial](https://mpitutorial.com/tutorials/mpi-send-and-receive/) (MIT License) for more narrative detail and examples in C.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "199fdfe5-1a8a-4f84-a1e5-437f3021af2b",
+   "metadata": {},
+   "source": [
+    "## Initializing the cluster\n",
+    "\n",
+    "As with all tutorials, we will start by creating a cluster and loading the rank and size."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "39a1c079-9f64-46cd-b4cc-148bc5bc4f9a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:01<00:00,  1.50engine/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import logging\n",
+    "import ipyparallel as ipp\n",
+    "\n",
+    "# create a cluster\n",
+    "rc = ipp.Cluster(engines=\"mpi\", n=2, log_level=logging.WARNING).start_and_connect_sync(activate=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "1184e9f8-27aa-43b8-b758-28a4bd3ae1c0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[stdout:1] I am rank 1 / 2\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[stdout:0] I am rank 0 / 2\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%px\n",
+    "# Find out rank, size\n",
+    "from mpi4py import MPI\n",
+    "\n",
+    "comm = MPI.COMM_WORLD\n",
+    "world_rank = comm.Get_rank()\n",
+    "world_size = comm.Get_size()\n",
+    "\n",
+    "print(f\"I am rank {world_rank} / {world_size}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e83314df-d0f9-4724-8237-7669a142df2b",
+   "metadata": {},
+   "source": [
+    "## MPI send/recv \n",
+    "\n",
+    "[original tutorial](https://mpitutorial.com/tutorials/mpi-send-and-receive/#mpi-send--recv-program)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "94957944-a17e-468a-9b6e-7590f53c204f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;31mOut[0:2]: \u001b[0m-1"
+      ]
+     },
+     "metadata": {
+      "after": null,
+      "completed": null,
+      "data": {},
+      "engine_id": 0,
+      "engine_uuid": "9c60c52a-d1367323e6c95e0468b016bf",
+      "error": null,
+      "execute_input": "\nnumber = None\n\nif world_rank == 0:\n    number = -1\n    comm.send(number, dest=1)\nelif world_rank == 1:\n    number = comm.recv(source=0)\n    print(f\"Process 1 received number {number} from process 0\")\n\nnumber\n",
+      "execute_result": {
+       "data": {
+        "text/plain": "-1"
+       },
+       "execution_count": 2,
+       "metadata": {}
+      },
+      "follow": null,
+      "msg_id": null,
+      "outputs": [],
+      "received": null,
+      "started": null,
+      "status": null,
+      "stderr": "",
+      "stdout": "",
+      "submitted": "2023-04-12T07:41:37.963480Z"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[stdout:1] Process 1 received number -1 from process 0\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;31mOut[1:2]: \u001b[0m-1"
+      ]
+     },
+     "metadata": {
+      "after": null,
+      "completed": null,
+      "data": {},
+      "engine_id": 1,
+      "engine_uuid": "924ea006-419760b62852971ad6e67382",
+      "error": null,
+      "execute_input": "\nnumber = None\n\nif world_rank == 0:\n    number = -1\n    comm.send(number, dest=1)\nelif world_rank == 1:\n    number = comm.recv(source=0)\n    print(f\"Process 1 received number {number} from process 0\")\n\nnumber\n",
+      "execute_result": {
+       "data": {
+        "text/plain": "-1"
+       },
+       "execution_count": 2,
+       "metadata": {}
+      },
+      "follow": null,
+      "msg_id": null,
+      "outputs": [],
+      "received": null,
+      "started": null,
+      "status": null,
+      "stderr": "",
+      "stdout": "Process 1 received number -1 from process 0\n",
+      "submitted": "2023-04-12T07:41:37.963713Z"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%px\n",
+    "\n",
+    "number = None\n",
+    "\n",
+    "if world_rank == 0:\n",
+    "    number = -1\n",
+    "    comm.send(number, dest=1)\n",
+    "elif world_rank == 1:\n",
+    "    number = comm.recv(source=0)\n",
+    "    print(f\"Process 1 received number {number} from process 0\")\n",
+    "\n",
+    "number"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80115ddc-1248-4d3c-a3b7-aecd6a525467",
+   "metadata": {},
+   "source": [
+    "## MPI ping pong program\n",
+    "\n",
+    "[original tutorial](https://mpitutorial.com/tutorials/mpi-send-and-receive/#mpi-ping-pong-program)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "440eb2a6-2a4f-401c-9d89-3c66ece0c103",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[stdout:1] 1 received ping_pong_count 1 from 0\n",
+       "1 sent and incremented ping_pong_count 2 to 0\n",
+       "1 received ping_pong_count 3 from 0\n",
+       "1 sent and incremented ping_pong_count 4 to 0\n",
+       "1 received ping_pong_count 5 from 0\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[stdout:0] 0 sent and incremented ping_pong_count 1 to 1\n",
+       "0 received ping_pong_count 2 from 1\n",
+       "0 sent and incremented ping_pong_count 3 to 1\n",
+       "0 received ping_pong_count 4 from 1\n",
+       "0 sent and incremented ping_pong_count 5 to 1\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%px\n",
+    "\n",
+    "import time\n",
+    "\n",
+    "PING_PONG_LIMIT = 5\n",
+    "\n",
+    "ping_pong_count = 0\n",
+    "partner_rank = (world_rank + 1) % 2\n",
+    "\n",
+    "while ping_pong_count < PING_PONG_LIMIT:\n",
+    "    if world_rank == ping_pong_count % 2:\n",
+    "        ping_pong_count += 1\n",
+    "        comm.send(ping_pong_count, dest=partner_rank)\n",
+    "        print(f\"{world_rank} sent and incremented ping_pong_count {ping_pong_count} to {partner_rank}\")\n",
+    "    else:\n",
+    "        ping_pong_count = comm.recv(source=partner_rank)\n",
+    "        print(f\"{world_rank} received ping_pong_count {ping_pong_count} from {partner_rank}\")\n",
+    "\n",
+    "    # Make sure the output is synchronized\n",
+    "    # (this is not necessary in IPython Parallel)\n",
+    "    comm.Barrier()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1faad8bb-f016-42d1-8aa3-49bf7cd5d5d4",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Ring program\n",
+    "\n",
+    "\n",
+    "[original tutorial](https://mpitutorial.com/tutorials/mpi-send-and-receive/#ring-program)\n",
+    "\n",
+    "\n",
+    "This one uses more than 2 processes, so stop our first cluster and start a new one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "9e9a65e7-8732-40cc-b073-7bd960f87e07",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Stopping controller\n",
+      "Controller stopped: {'exit_code': 0, 'pid': 38004, 'identifier': 'ipcontroller-1681285126-r1fp-37933'}\n",
+      "Stopping engine(s): 1681285128\n",
+      "engine set stopped 1681285128: {'exit_code': 0, 'pid': 38018, 'identifier': 'ipengine-1681285126-r1fp-1681285128-37933'}\n",
+      "Starting 4 engines with <class 'ipyparallel.cluster.launcher.MPIEngineSetLauncher'>\n",
+      "100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:01<00:00,  2.78engine/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    rc.cluster.stop_cluster_sync()\n",
+    "except NameError:\n",
+    "    # rc undefined, e.g. not starting from scratch\n",
+    "    pass\n",
+    "\n",
+    "# start a cluster and connect to it\n",
+    "rc = ipp.Cluster(engines=\"mpi\", n=4).start_and_connect_sync(activate=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "71b07caf-d101-4dc9-b0d0-c5b99ccd1f9d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[stdout:1] 1 received b'0' from 0\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[stdout:2] 2 received b'01' from 1\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[stdout:0] 0 received b'0123' from 3\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[stdout:3] 3 received b'012' from 2\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%px\n",
+    "\n",
+    "from mpi4py import MPI\n",
+    "\n",
+    "comm = MPI.COMM_WORLD\n",
+    "world_rank = comm.Get_rank()\n",
+    "world_size = comm.Get_size()\n",
+    "\n",
+    "if world_rank != 0:\n",
+    "    token = comm.recv(source=world_rank - 1)\n",
+    "    print(f\"{world_rank} received {token} from {world_rank-1}\")\n",
+    "    token = token + f\"{world_rank}\".encode('ascii')\n",
+    "else:\n",
+    "    token = b\"0\"\n",
+    "\n",
+    "comm.send(token, dest=(world_rank + 1) % world_size)\n",
+    "\n",
+    "if world_rank == 0:\n",
+    "    token = comm.recv(source=world_size - 1)\n",
+    "    print(f\"{world_rank} received {token} from {world_size-1}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "64890cf5-4b28-44b5-aa3f-e93d9ca15d70",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "rc.cluster.stop_cluster_sync()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "00075b7ed8c444eb97071a3707e50303": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0c3ca24d35fc4dc88c1fa23905ccfdc1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "16056c4de69e4209ace26e5b72f73cc8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "42dad6562c97491691e977d9b45d1ca2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "442f4995d9494629ac34b663e1a313bc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_77832571dc9945699fa431aaf60f24a9",
+       "style": "IPY_MODEL_9fd188b48db842dfa8e2c7a7cd1b23cc",
+       "value": " 4/4 [00:02&lt;00:00,  1.96engine/s]"
+      }
+     },
+     "4b512d642a6840d9939b743196564cf2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "572b4a346aec4d81be009a3ac2da2612": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_00075b7ed8c444eb97071a3707e50303",
+       "max": 4,
+       "style": "IPY_MODEL_42dad6562c97491691e977d9b45d1ca2",
+       "value": 4
+      }
+     },
+     "662312ef5f274591b84e3d644ac3e0d1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "6624a6cb4c28493d9c4aa1576d226946": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "68e50b829ba94a9aa73b29533cc7bef1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_9ded3a6800244a2c80d9a1bcaa9a4a5b",
+       "style": "IPY_MODEL_8de4c73f29c441ba91a4aed26f9b06bb",
+       "value": "100%"
+      }
+     },
+     "77832571dc9945699fa431aaf60f24a9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7d56b4fa55be4efb96f8d47a4fcff66e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_7e774ce0eb6c4b008764245c5f9db291",
+        "IPY_MODEL_b2997f4ca3224e28a6238c0ed1e67def",
+        "IPY_MODEL_c161a918e88e4d8b82f777a85b40278d"
+       ],
+       "layout": "IPY_MODEL_c88715f7a1b8410e9d72b28e19703194"
+      }
+     },
+     "7e774ce0eb6c4b008764245c5f9db291": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_9bddffbc41eb44a99ec28c7e2af77ffb",
+       "style": "IPY_MODEL_662312ef5f274591b84e3d644ac3e0d1",
+       "value": "100%"
+      }
+     },
+     "8de4c73f29c441ba91a4aed26f9b06bb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "9bddffbc41eb44a99ec28c7e2af77ffb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9ded3a6800244a2c80d9a1bcaa9a4a5b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9fd188b48db842dfa8e2c7a7cd1b23cc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "b2997f4ca3224e28a6238c0ed1e67def": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_4b512d642a6840d9939b743196564cf2",
+       "max": 2,
+       "style": "IPY_MODEL_0c3ca24d35fc4dc88c1fa23905ccfdc1",
+       "value": 2
+      }
+     },
+     "c161a918e88e4d8b82f777a85b40278d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6624a6cb4c28493d9c4aa1576d226946",
+       "style": "IPY_MODEL_ce92ee5594924e63af2e9e3ce8ae9154",
+       "value": " 2/2 [00:01&lt;00:00,  1.56s/engine]"
+      }
+     },
+     "c88715f7a1b8410e9d72b28e19703194": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ce92ee5594924e63af2e9e3ce8ae9154": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "d6f225fcfd5943cbabb0b0c6cd356ca6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_68e50b829ba94a9aa73b29533cc7bef1",
+        "IPY_MODEL_572b4a346aec4d81be009a3ac2da2612",
+        "IPY_MODEL_442f4995d9494629ac34b663e1a313bc"
+       ],
+       "layout": "IPY_MODEL_16056c4de69e4209ace26e5b72f73cc8"
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
intro covering ipython-parallel and `%%px` and [send-recv](https://mpitutorial.com/tutorials/mpi-send-and-receive/) from mpitutorial.com.

I figure it makes sense to put

For now, I've copied ~no narrative content or explanation, only examples. I'm not sure how much to copy over / translate to Python vs just referring to the original.

I think it does make sense to include mpi4py-specific discussion of numpy arrays, buffers, etc.