### PR TITLE
fixes for ipyparallel output issues

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   DEB_PYTHON_INSTALL_LAYOUT: deb_system
+  IPP_NONINTERACTIVE: "1"
 
 defaults:
   run:

--- a/environment.yml
+++ b/environment.yml
@@ -12,3 +12,5 @@ dependencies:
   - pandas
   - autopep8
   - fenics-dolfinx
+  - pip:
+    - ipyparallel>=8.6


### PR DESCRIPTION
- update to ipp 8.6, fixes KeyError
- enables IPP_NONINTERACTIVE=1 to disable streaming output, progress during CI builds (new in 8.6)

temporarily installed via pip instead of conda since it's not ready on conda-forge