### PR TITLE
cache executed notebooks

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -25,6 +25,12 @@ jobs:
       - name: Install common packages
         uses: ./.github/actions/install-dependencies
 
+      - name: cache executed notebooks
+        uses: actions/cache@v3
+        with:
+          path: _build/.jupyter_cache
+          key: jupyter-cache-${{ hashFiles('environment.yml') }}
+
       - name: Build the book
         run:
           jupyter-book build . -W

--- a/_config.yml
+++ b/_config.yml
@@ -5,10 +5,10 @@ title: MPI tutorial
 author: Jørgen S. Dokken
 logo: logo.png
 
-# Force re-execution of notebooks on each build.
+# Cache execution of notebooks
 # See https://jupyterbook.org/content/execute.html
 execute:
-  execute_notebooks: force
+  execute_notebooks: cache
   timeout: 1800
   exclude_patterns:
     # temporarily skip dolfinx rebuild so we can figure it out


### PR DESCRIPTION
should get quicker rebuilds when most notebooks don't change